### PR TITLE
ZCS-2340 Tasks: The priority icon color should be keep when selected that task

### DIFF
--- a/src/zimlet/com_zimbra_attachmail/attachmail.css
+++ b/src/zimlet/com_zimbra_attachmail/attachmail.css
@@ -80,7 +80,7 @@
     color: #ffffff;
 }
 
-.Row-selected .svg-icon {
+.AttachMailList .Row-selected .svg-icon {
     fill: #fff;
 }
 


### PR DESCRIPTION
- Restrict style to be applied to zimlet component only, not to entire webclient