### PR TITLE
ZCS-1679 Error message shows after deselect a mail in Attach Mail popup window by uncheck checkbox

### DIFF
--- a/src/zimlet/com_zimbra_attachmail/attachmail.js
+++ b/src/zimlet/com_zimbra_attachmail/attachmail.js
@@ -68,7 +68,7 @@ function() {
 	var attachDialog = this._attachDialog = appCtxt.getAttachDialog();
 	attachDialog.setTitle(ZmMsg.attachMail);
     this.removePrevAttDialogContent(attachDialog._getContentDiv().firstChild);
-    if (!this.AttachContactsView || !this.AttachContactsView.attachDialog){
+    if (!this.AMV || !this.AMV.attachDialog){
 	    this.AMV = new AttachMailTabView(this._attachDialog, this);
     }
 
@@ -411,6 +411,7 @@ function(params) {
 	}
 	var bcView = this._tabAttachMailView;
 	bcView.set(this._list);
+	bcView._controller.setList(this._list);
 };
 
 /**


### PR DESCRIPTION
- make sure caching of objects work by pointing to right property name
- pass model reference to controller as well when setting it in view