### PR TITLE
ZBUG-849: fixed missing icon of Clear Search Highlights

### DIFF
--- a/src/zimlet/com_zimbra_srchhighlighter/searchhighlighter.js
+++ b/src/zimlet/com_zimbra_srchhighlighter/searchhighlighter.js
@@ -206,7 +206,7 @@ SearchHighlighterZimlet.prototype.addMenuButton = function(controller, menu) {
 		var op = {
 			id:			 ID,
 			text:		  text,
-			image:		  "search"
+			image:		  "Search"
 		};
 		var opDesc = ZmOperation.defineOperation(null, op);
 		menu.addOp(ID, 1000);//add the button at the bottom


### PR DESCRIPTION
Problem:
Icon of Clear Search Highlights is not shown.

Root cause:
The string of "image" was "search". Then html code was generated as `<div class="Imgsearch"></div>`.
It should be `<div class="ImgSearch"></div>`.

Fix:
Change the name of "image" in associative array (hash) from "search" to "Search". Then the name of the class of the above div tag becomes "ImgSearch".