### PR TITLE
ZCS-5471 Upgrade httpclient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 build
+/bin/
+.classpath
+.project
+.settings
+

--- a/ivy.xml
+++ b/ivy.xml
@@ -7,7 +7,6 @@
  <dependencies>
   <dependency org="commons-cli" name="commons-cli" rev="1.2" />
   <dependency org="commons-codec" name="commons-codec" rev="1.7" />
-  <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
   <dependency org="com.google.guava" name="guava" rev="23.0" />
   <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />


### PR DESCRIPTION
Upgrading httpclient library. The library is not required, so removing reference from ivy.xml
Verified "ant jar" and "ant package-zimlets" works without any issues.