### PR TITLE
ZCS-10908: fixed script error raised when Contacts is disabled

### DIFF
--- a/src/zimlet/com_zimbra_email/UnknownPersonSlide.js
+++ b/src/zimlet/com_zimbra_email/UnknownPersonSlide.js
@@ -531,14 +531,14 @@ UnknownPersonSlide.prototype._getActionedContact =
 		// actionObject can be a ZmContact, a String, or a generic Object (phew!)
 		var contact;
 		var addr = this.emailZimlet._actionObject;
+		var cl;
 		if (addr) {
 			if (addr.isZmContact) {
 				contact = this._actionObject;
-			} else if (AjxUtil.isString(addr)) {
-				addr = this.emailZimlet._getAddress(addr);
-				contact = AjxDispatcher.run("GetContacts").getContactByEmail(addr);
 			} else {
-				contact = AjxDispatcher.run("GetContacts").getContactByEmail(addr.address);
+				address = AjxUtil.isString(addr) ? this.emailZimlet._getAddress(addr) : addr.address;
+				cl = AjxDispatcher.run("GetContacts");
+				contact = cl && cl.getContactByEmail(address) || null;
 			}
 		}
 		this._isNewContact = false;


### PR DESCRIPTION
**Problem:**
When Contacts feature is disabled (i.e. zimbraFeatureContactsEnabled FALSE) and a calendar icon for Create Appointment action in a contact card is clicked, it does not work but an error is shown in developer tools of a browser.
![screenshot](https://user-images.githubusercontent.com/32184593/135031117-6a183371-0f78-4b88-8db2-533597c2033d.png)
 
**Root cause:**
When Contacts feature is disabled and compose page has not been accessed, `AjxDispatcher.run("GetContacts")` returns `undefined`. Then an error is thrown at `AjxDispatcher.run("GetContacts").getContactByEmail(address)`

**Change:** 
null/undefined check logic is added.