### PR TITLE
ZBUG-1975 Portuguese, Date format showing wrong

### DIFF
--- a/src/zimlet/com_zimbra_date/com_zimbra_date_pt_BR.properties
+++ b/src/zimlet/com_zimbra_date/com_zimbra_date_pt_BR.properties
@@ -194,8 +194,8 @@ format16.rule = now month={monthname},{datenum}
 format17.pattern = {datenum} {monthname}.? {yearnum}
 format17.rule = now year={yearnum},{monthname},{datenum}
 
-# e.g. 9/23/1970
-format18.pattern = {monthnum}/{datenum}/{yearnum}
+# e.g. 23/09/1970
+format18.pattern = {datenum}/{monthnum}/{yearnum}
 format18.rule = now year={yearnum},{monthnum},{datenum}
 
 # e.g. 1970-09-23


### PR DESCRIPTION
-changed the date format from mm/dd/yyyy to dd/mm/yyyy in com_zimbra_date_pt_BR.properties file .