### PR TITLE
ZCS-12545: added com_zimbra_gotourl zimlet

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@
 	<property name="generated.java.dir" location="${generated.dir}/src/java" />
 
 	<property name="zimlets-zss" value="com_zimbra_zss"/>
-	<property name="zimlets" value="com_zimbra_mailarchive,com_zimbra_phone,com_zimbra_url,com_zimbra_email,com_zimbra_date,com_zimbra_ymemoticons,com_zimbra_attachmail,com_zimbra_attachcontacts,com_zimbra_srchhighlighter,com_zimbra_webex"/>
+	<property name="zimlets" value="com_zimbra_mailarchive,com_zimbra_phone,com_zimbra_url,com_zimbra_email,com_zimbra_date,com_zimbra_ymemoticons,com_zimbra_attachmail,com_zimbra_attachcontacts,com_zimbra_srchhighlighter,com_zimbra_webex,com_zimbra_gotourl"/>
 	<property name="zimlets-offline" value=""/>
 	<property name="zimlets-example" value="com_zimbra_example_*"/>
     <property name="zimlets-experimental" value="com_zimbra_amzn,com_zimbra_asterisk,com_zimbra_asteriskmwi,com_zimbra_blog,com_zimbra_browserperf,com_zimbra_edu,com_zimbra_evite,com_zimbra_html,com_zimbra_jspsample,com_zimbra_photo,com_zimbra_po,com_zimbra_videos,com_zimbra_webex,com_zimbra_wikipedia,com_zimbra_xslt,com_zimbra_ytraffic,com_zimbra_calscheduler,com_zimbra_ybabelfish,com_zimbra_speak"/>

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Go to URL
+description = Provides Go to URL function on address bubble
+goToUrl = Go to URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl.xml
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl.xml
@@ -1,0 +1,30 @@
+<!--
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Zimlets
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * The contents of this file are subject to the Common Public Attribution License Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at: https://www.zimbra.com/license
+ * The License is based on the Mozilla Public License Version 1.1 but Sections 14 and 15
+ * have been added to cover use of software over a computer network and provide for limited attribution
+ * for the Original Developer. In addition, Exhibit A has been modified to be consistent with Exhibit B.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ * See the License for the specific language governing rights and limitations under the License.
+ * The Original Code is Zimbra Open Source Web Client.
+ * The Initial Developer of the Original Code is Zimbra, Inc.  All rights to the Original Code were
+ * transferred by Zimbra, Inc. to Synacor, Inc. on September 14, 2015.
+ *
+ * All portions of the code are Copyright (C) 2022 Synacor, Inc. All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+-->
+<zimlet name="com_zimbra_gotourl"
+        version="1.0"
+        label="${msg.zimletLabel}"
+        target="main view-window"
+        description="${msg.description}">
+    <include>gotourl.js</include>
+    <handlerObject>com_zimbra_gotourl_handlerObject</handlerObject>
+</zimlet>

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ar.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ar.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u0627\u0644\u0627\u0646\u062a\u0642\u0627\u0644 \u0625\u0644\u0649 \u0639\u0646\u0648\u0627\u0646 URL\u200f
+description = \u064a\u0648\u0641\u0631 \u0627\u0644\u0627\u0646\u062a\u0642\u0627\u0644 \u0625\u0644\u0649 \u0648\u0638\u064a\u0641\u0629 URL \u0641\u064a \u0641\u0642\u0627\u0639\u0629 \u0627\u0644\u0639\u0646\u0648\u0627\u0646
+goToUrl = \u0627\u0644\u0627\u0646\u062a\u0642\u0627\u0644 \u0625\u0644\u0649 \u0639\u0646\u0648\u0627\u0646 URL\u200f

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ca.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ca.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = V\u00e9s a URL
+description = Proporciona la funci\u00f3 Anar a URL a la bombolla d'adreces
+goToUrl = V\u00e9s a URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_da.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_da.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = G\u00e5 til URL
+description = Tilbyder G\u00e5 til URL-funktion p\u00e5 adresseboblen
+goToUrl = G\u00e5 til URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_de.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_de.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = URL \u00f6ffnen
+description = Bietet die Funktion Gehe zu URL in der Adressblase
+goToUrl = URL \u00f6ffnen

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_en_AU.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_en_AU.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Go to URL
+description = Provides Go to URL function on address bubble
+goToUrl = Go to URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_en_GB.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_en_GB.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Go to URL
+description = Provides Go to URL function on address bubble
+goToUrl = Go to URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_es.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_es.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Ir a la URL
+description = Proporciona la funci\u00f3n Ir a URL en la burbuja de direcci\u00f3n
+goToUrl = Ir a la URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_eu.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_eu.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Joan URL-ra
+description = Joan URL-era funtzioa eskaintzen du helbide-burbuilan
+goToUrl = Joan URL-ra

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_fr.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_fr.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Aller \u00e0 l\u2019URL
+description = Fournit la fonction Aller \u00e0 l'URL sur la bulle d'adresse
+goToUrl = Aller \u00e0 l\u2019URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_fr_CA.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_fr_CA.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Allez \u00e0 l\u2019URL
+description = Fournit la fonction Aller \u00e0 l'URL sur la bulle d'adresse
+goToUrl = Allez \u00e0 l\u2019URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_hi.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_hi.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = URL \u092a\u0930 \u091c\u093e\u090f\u0901
+description = \u092a\u0924\u093e \u092c\u092c\u0932 \u092a\u0930 URL \u092b\u093c\u0902\u0915\u094d\u0936\u0928 \u092a\u0930 \u091c\u093e\u090f\u0902 \u092a\u094d\u0930\u0926\u093e\u0928 \u0915\u0930\u0924\u093e \u0939\u0948
+goToUrl = URL \u092a\u0930 \u091c\u093e\u090f\u0901

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_hr.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_hr.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Go to URL
+description = Pru\u017ea funkciju Idi na URL na obla\u010di\u0107u adrese
+goToUrl = Go to URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_hu.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_hu.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Ugr\u00e1s URL-re
+description = Ugr\u00e1s az URL-hez funkci\u00f3t biztos\u00edt a c\u00edmbubor\u00e9kon
+goToUrl = Ugr\u00e1s URL-re

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_in.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_in.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Buka URL
+description = Menyediakan fungsi Buka URL pada balon alamat
+goToUrl = Buka URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_it.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_it.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Vai a URL
+description = Fornisce la funzione Vai all'URL sulla bolla dell'indirizzo
+goToUrl = Vai a URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_iw.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_iw.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u05e2\u05d1\u05d5\u05e8 \u05d0\u05dc \u05db\u05ea\u05d5\u05d1\u05ea \u05d0\u05d9\u05e0\u05d8\u05e8\u05e0\u05d8
+description = \u05de\u05e1\u05e4\u05e7 \u05e4\u05d5\u05e0\u05e7\u05e6\u05d9\u05d4 \u05e2\u05d1\u05d5\u05e8 \u05d0\u05dc \u05db\u05ea\u05d5\u05d1\u05ea URL \u05d1\u05d1\u05d5\u05e2\u05ea \u05db\u05ea\u05d5\u05d1\u05ea
+goToUrl = \u05e2\u05d1\u05d5\u05e8 \u05d0\u05dc \u05db\u05ea\u05d5\u05d1\u05ea \u05d0\u05d9\u05e0\u05d8\u05e8\u05e0\u05d8

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ja.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ja.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = URL\u306b\u79fb\u52d5
+description = \u30a2\u30c9\u30ec\u30b9 \u30d0\u30d6\u30eb\u306b Go to URL \u6a5f\u80fd\u3092\u63d0\u4f9b
+goToUrl = URL\u306b\u79fb\u52d5

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ko.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ko.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = URL\ub85c \uac00\uae30
+description = \uc8fc\uc18c \ud48d\uc120\uc5d0 URL \uac00\uae30 \uae30\ub2a5 \uc81c\uacf5
+goToUrl = URL\ub85c \uac00\uae30

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_lo.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_lo.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u0ec4\u0e9b\u0e97\u0eb5\u0ec8 URL
+description = \u0ec3\u0eab\u0ec9\u0e9f\u0eb1\u0e87\u0e8a\u0eb1\u0e99 Go to URL \u0ec3\u0e99 bubble \u0e97\u0eb5\u0ec8\u0ea2\u0eb9\u0ec8
+goToUrl = \u0ec4\u0e9b\u0e97\u0eb5\u0ec8 URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ms.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ms.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Pergi ke URL
+description = Menyediakan fungsi Pergi ke URL pada gelembung alamat
+goToUrl = Pergi ke URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_nl.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_nl.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Naar URL
+description = Biedt Ga naar URL-functie op adresballon
+goToUrl = Naar URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_no.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_no.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = G\u00e5 til URL-adresse
+description = Gir G\u00e5 til URL-funksjon p\u00e5 adresseboblen
+goToUrl = G\u00e5 til URL-adresse

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_pl.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_pl.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Przejd\u017a do adresu URL
+description = Zapewnia funkcj\u0119 Przejd\u017a do adresu URL w dymku adresu
+goToUrl = Przejd\u017a do adresu URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_pt.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_pt.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Aceder ao URL
+description = Fornece a fun\u00e7\u00e3o Ir para URL no bal\u00e3o de endere\u00e7o
+goToUrl = Aceder ao URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_pt_BR.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_pt_BR.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Ir para URL
+description = Fornece a fun\u00e7\u00e3o Ir para URL no bal\u00e3o de endere\u00e7o
+goToUrl = Ir para URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ro.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ro.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Salt la URL
+description = Ofer\u0103 func\u021bia Go to URL pe balonul de adres\u0103
+goToUrl = Salt la URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ru.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ru.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u043f\u043e URL-\u0430\u0434\u0440\u0435\u0441\u0443
+description = \u041f\u0440\u0435\u0434\u043e\u0441\u0442\u0430\u0432\u043b\u044f\u0435\u0442 \u0444\u0443\u043d\u043a\u0446\u0438\u044e \u00ab\u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u043a URL\u00bb \u0432 \u0430\u0434\u0440\u0435\u0441\u043d\u043e\u0439 \u0432\u044b\u043d\u043e\u0441\u043a\u0435.
+goToUrl = \u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u043f\u043e URL-\u0430\u0434\u0440\u0435\u0441\u0443

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_sl.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_sl.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Odprite URL
+description = Zagotavlja funkcijo Pojdi na URL v naslovnem obla\u010dku
+goToUrl = Odprite URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_sv.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_sv.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = G\u00e5 till URL
+description = Tillhandah\u00e5ller G\u00e5 till URL-funktion p\u00e5 adressbubblan
+goToUrl = G\u00e5 till URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ta.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_ta.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = URL-\u0b95\u0bcd\u0b95\u0bc1\u0b9a\u0bcd \u0b9a\u0bc6\u0bb2\u0bcd
+description = \u0bae\u0bc1\u0b95\u0bb5\u0bb0\u0bbf \u0b95\u0bc1\u0bae\u0bbf\u0bb4\u0bbf\u0baf\u0bbf\u0bb2\u0bcd Go to URL \u0b9a\u0bc6\u0baf\u0bb2\u0bcd\u0baa\u0bbe\u0b9f\u0bcd\u0b9f\u0bc8 \u0bb5\u0bb4\u0b99\u0bcd\u0b95\u0bc1\u0b95\u0bbf\u0bb1\u0ba4\u0bc1
+goToUrl = URL-\u0b95\u0bcd\u0b95\u0bc1\u0b9a\u0bcd \u0b9a\u0bc6\u0bb2\u0bcd

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_th.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_th.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u0e44\u0e1b\u0e17\u0e35\u0e48 URL
+description = \u0e43\u0e2b\u0e49\u0e1f\u0e31\u0e07\u0e01\u0e4c\u0e0a\u0e31\u0e19\u0e44\u0e1b\u0e17\u0e35\u0e48 URL \u0e1a\u0e19\u0e01\u0e23\u0e2d\u0e1a\u0e17\u0e35\u0e48\u0e2d\u0e22\u0e39\u0e48
+goToUrl = \u0e44\u0e1b\u0e17\u0e35\u0e48 URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_tr.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_tr.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = URL\u2019ye git
+description = Adres balonunda URL'ye git i\u015flevi sa\u011flar
+goToUrl = URL\u2019ye git

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_uk.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_uk.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u0434\u043e URL-\u0430\u0434\u0440\u0435\u0441\u0438
+description = \u0417\u0430\u0431\u0435\u0437\u043f\u0435\u0447\u0443\u0454 \u0444\u0443\u043d\u043a\u0446\u0456\u044e \u00ab\u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u0434\u043e URL\u00bb \u0443 \u043f\u0456\u0434\u043a\u0430\u0437\u0446\u0456 \u0430\u0434\u0440\u0435\u0441\u0438
+goToUrl = \u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u0434\u043e URL-\u0430\u0434\u0440\u0435\u0441\u0438

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_vi.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_vi.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = Truy c\u1eadp URL
+description = Cung c\u1ea5p ch\u1ee9c n\u0103ng Chuy\u1ec3n \u0111\u1ebfn URL tr\u00ean bong b\u00f3ng \u0111\u1ecba ch\u1ec9
+goToUrl = Truy c\u1eadp URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_zh_CN.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_zh_CN.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u524d\u5f80 URL
+description = \u5728\u5730\u5740\u6c14\u6ce1\u4e0a\u63d0\u4f9b\u8f6c\u5230 URL \u529f\u80fd
+goToUrl = \u524d\u5f80 URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_zh_HK.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_zh_HK.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u524d\u5f80 URL
+description = \u5728\u5730\u5740\u6c23\u6ce1\u4e0a\u63d0\u4f9b\u8f49\u5230 URL \u529f\u80fd
+goToUrl = \u524d\u5f80 URL

--- a/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_zh_TW.properties
+++ b/src/zimlet/com_zimbra_gotourl/com_zimbra_gotourl_zh_TW.properties
@@ -1,0 +1,20 @@
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Zimlets
+# Copyright (C) 2022 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+zimletLabel = \u79fb\u81f3 URL
+description = \u5728\u5730\u5740\u6c23\u6ce1\u4e0a\u63d0\u4f9b\u8f49\u5230 URL \u529f\u80fd
+goToUrl = \u79fb\u81f3 URL

--- a/src/zimlet/com_zimbra_gotourl/gotourl.js
+++ b/src/zimlet/com_zimbra_gotourl/gotourl.js
@@ -1,0 +1,84 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Zimlets
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * The contents of this file are subject to the Common Public Attribution License Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at: https://www.zimbra.com/license
+ * The License is based on the Mozilla Public License Version 1.1 but Sections 14 and 15
+ * have been added to cover use of software over a computer network and provide for limited attribution
+ * for the Original Developer. In addition, Exhibit A has been modified to be consistent with Exhibit B.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ * See the License for the specific language governing rights and limitations under the License.
+ * The Original Code is Zimbra Open Source Web Client.
+ * The Initial Developer of the Original Code is Zimbra, Inc.  All rights to the Original Code were
+ * transferred by Zimbra, Inc. to Synacor, Inc. on September 14, 2015.
+ *
+ * All portions of the code are Copyright (C) 2022 Synacor, Inc. All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+
+function com_zimbra_gotourl_handlerObject() {
+}
+
+com_zimbra_gotourl_handlerObject.prototype = new ZmZimletBase();
+com_zimbra_gotourl_handlerObject.prototype.constructor = com_zimbra_gotourl_handlerObject;
+
+com_zimbra_gotourl_handlerObject.prototype.init =
+function() {
+    var text = this.getMessage("goToUrl");
+    this._op = ZmOperation.registerOp(ZmId.OP_GO_TO_URL, {image:"URL", translatedText: text});
+};
+
+com_zimbra_gotourl_handlerObject.prototype._goToUrlListener =
+function(controller, ev) {
+    var addr = this._getAddress(controller._actionEv.address);
+    var parts = addr.split("@");
+    if (!parts.length) {
+        return;
+    }
+    var domain = parts[1];
+    var pieces = domain.split(".");
+    var url = "https://" + (pieces.length <= 2 ? "www." + domain : domain);
+    window.open(url, "_blank");
+};
+
+com_zimbra_gotourl_handlerObject.prototype._getAddress =
+function(obj) {
+    return obj.isAjxEmailAddress ? obj.address : obj;
+};
+
+com_zimbra_gotourl_handlerObject.prototype.onBubbleActionMenuOps =
+function(controller, ops) {
+    if (!controller || !ops) {
+        return;
+    }
+    var newMsgIndex = -1;
+    var contactIndex = -1;
+    for (var i = 0; i < ops.length; i++) {
+        if (ops[i] === ZmOperation.NEW_MESSAGE) {
+            newMsgIndex = i;
+        } else if (ops[i] === ZmOperation.CONTACT) {
+            contactIndex = i;
+        }
+    }
+    if (contactIndex > 0) {
+        ops.splice(contactIndex + 1, 0, ZmOperation.GO_TO_URL);
+    } else if (newMsgIndex > 0) {
+        ops.splice(newMsgIndex + 1, 0, ZmOperation.GO_TO_URL);
+    }
+};
+
+com_zimbra_gotourl_handlerObject.prototype.onBubbleActionMenu =
+function(controller, menuItems, menu) {
+    for (var i = 0; i < menuItems.length; i++) {
+        var menuItem = menuItems[i];
+        if (menuItem === ZmOperation.GO_TO_URL) {
+            menu.addSelectionListener(menuItem, this._goToUrlListener.bind(this, controller));
+            break;
+        }
+    }
+};


### PR DESCRIPTION
Moving implementation of "Go to URL" action menu from zm-web-client to a zimlet.

* Zimlet name: com_zimbra_gotourl
* `_goToUrlListener` and `_getAddress ` functions are moved from ZmBaseController.js
* PR on zm-web-client: https://github.com/Zimbra/zm-web-client/pull/759

Reference:
Go to URL function was introduced in the following change.
https://github.com/Zimbra/zm-web-client/commit/383075970c192a5ba9fdf885ec1bd80c15aa837a